### PR TITLE
Resolve #11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "6"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ NB: CM arbiter key MUST be provided as per section 7.1 of the [Hypercat 3.0 spec
 
   - name: Container name (required every time)
   - type: Container type (driver|store|app)
+  - key: Container arbiter key
 
 ##### Response
 
@@ -127,6 +128,7 @@ NB: Container arbiter key (see developer guide) MUST be provided as per section 
 ###### Error
 
   - 401: Missing API key (see description above)
+  - 401: Invalid API key (see description above)
   - 500: Container type unknown by arbiter
   - 403: Container type [type] cannot use arbiter token minting capabilities as it is not a store type
   - 409: Store shared secret already retrieved

--- a/README.md
+++ b/README.md
@@ -62,16 +62,40 @@ NB: CM arbiter key MUST be provided as per section 7.1 of the [Hypercat 3.0 spec
 
 ##### Parameters
 
-  - data: A JSON string with the following properties:
-    - name: Container name (required every time)
-    - key:  Container arbiter key
-    - type: Container type (driver|store|app)
+  - name: Container name (required every time)
+  - type: Container type (driver|store|app)
 
 ##### Response
 
 ###### Success
 
   - 200: [JSON-formatted updated container record]
+
+###### Error
+
+  - 401:
+    - Missing API key (see description above)
+    - Unauthorized: Arbiter key invalid
+
+#### /cm/delete-container-info
+
+##### Description
+
+Method: POST
+
+Deletes a containers record by name.
+
+NB: CM arbiter key MUST be provided as per section 7.1 of the [Hypercat 3.0 specs](http://shop.bsigroup.com/upload/276778/PAS_212.pdf). The arbiter will not accept requests that don't include a key that matches that passed to it in the `CM_KEY` environment variable on launch.
+
+##### Parameters
+
+  - name: Container name
+
+##### Response
+
+###### Success
+
+  - 200
 
 ###### Error
 

--- a/main.js
+++ b/main.js
@@ -217,8 +217,6 @@ app.get('/store/secret', function (req, res) {
 			return;
 		}
 
-		console.log("[/store/secret]" + req.container.name + " registered");
-
 		req.container.secret = buffer;
 		res.send(buffer.toString('base64'));
 	});

--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ app.all([ '/cat', '/token', '/store/*', '/cm/*'], function (req, res, next) {
 	var key = req.get('X-Api-Key') || (creds && creds.name);
 
 	if (!key) {
-		res.status(401).send('Missing API Key');
+		res.status(401).send('Missing API key');
 		return;
 	}
 
@@ -188,6 +188,13 @@ app.post('/token', function(req, res){
 /**********************************************************/
 
 app.get('/store/secret', function (req, res) {
+	if (!req.container) {
+		// NOTE: This can also happen if the CM never uploaded store key
+		//       but should never happen if the CM is up to spec.
+		res.status(401).send('Invalid API key');
+		return;
+	}
+
 	if (!req.container.type) {
 		// NOTE: This should never happen if the CM is up to spec.
 		res.status(500).send('Container type unknown by arbiter');

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "0.1.0",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
-    "registry": "registry.iotdatabox.com"
+    "databox-registry": "registry.iotdatabox.com"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node main.js",
     "build": "docker build -f Dockerfile-x86 -t databox/databox-arbiter .",
-    "deploy": "docker tag databox/databox-arbiter $npm_package_config_registry/databox-arbiter && docker push $npm_package_config_registry/databox-arbiter",
+    "deploy": "docker tag databox/databox-arbiter $npm_package_config_databox_registry/databox-arbiter && docker push $npm_package_config_databox_registry/databox-arbiter",
     "build-arm": "docker build -f Dockerfile-arm -t databox/databox-arbiter-arm .",
-    "deploy-arm": "docker tag databox/databox-arbiter-arm $npm_package_config_registry/databox-arbiter-arm && docker push $npm_package_config_registry/databox-arbiter-arm",
+    "deploy-arm": "docker tag databox/databox-arbiter-arm $npm_package_config_databox_registry/databox-arbiter-arm && docker push $npm_package_config_databox_registry/databox-arbiter-arm",
     "clean": "node ./node_modules/modclean/bin/modclean.js -p ./node_modules/ -r",
     "getshell": "docker exec -i -t databox-arbiter /bin/bash",
     "kill": "docker kill databox-arbiter",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "databox-registry": "registry.iotdatabox.com"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha",
     "start": "node main.js",
     "build": "docker build -f Dockerfile-x86 -t databox/databox-arbiter .",
     "deploy": "docker tag databox/databox-arbiter $npm_package_config_databox_registry/databox-arbiter && docker push $npm_package_config_databox_registry/databox-arbiter",
@@ -45,5 +45,10 @@
     "macaroons.js": "^0.3.6",
     "modclean": "",
     "request": "^2.72.0"
+  },
+  "devDependencies": {
+    "assert": "^1.4.1",
+    "mocha": "^3.2.0",
+    "supertest": "^2.0.1"
   }
 }

--- a/test/cm.js
+++ b/test/cm.js
@@ -4,35 +4,34 @@ var supertest = require('supertest')(require('../main.js'));
 var assert = require('assert');
 
 describe('Test CM endpoints', function() {
-	it('GET /cm/upsert-container-info — No API key', (done) => {
+	it('POST /cm/upsert-container-info — No API key', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
-			.expect(401, 'Missing API Key', done);
+			.expect(401, 'Missing API key', done);
 	});
 
-
-	it('GET /cm/upsert-container-info — Invalid key (in header)', (done) => {
+	it('POST /cm/upsert-container-info — Invalid key (in header)', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
 			.set('X-Api-Key', 'aaa')
 			.expect(401, 'Unauthorized: Arbiter key invalid', done);
 	});
 
-	it('GET /cm/upsert-container-info — Invalid key (as basic auth)', (done) => {
+	it('POST /cm/upsert-container-info — Invalid key (as basic auth)', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
 			.auth('aaa')
 			.expect(401, 'Unauthorized: Arbiter key invalid', done);
 	});
 
-	it('GET /cm/upsert-container-info — No data', (done) => {
+	it('POST /cm/upsert-container-info — No data', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
 			.auth(process.env.CM_KEY)
 			.expect(400, 'Missing parameters', done);
 	});
 
-	it('GET /cm/upsert-container-info — No name', (done) => {
+	it('POST /cm/upsert-container-info — No name', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
 			.auth(process.env.CM_KEY)
@@ -45,7 +44,7 @@ describe('Test CM endpoints', function() {
 		name: 'test-store'
 	};
 
-	it('GET /cm/upsert-container-info — Minimum required', (done) => {
+	it('POST /cm/upsert-container-info — Minimum required', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
 			.auth(process.env.CM_KEY)
@@ -55,7 +54,7 @@ describe('Test CM endpoints', function() {
 			.expect(200, testData, done);
 	});
 
-	it('GET /cm/upsert-container-info — Upsert new data', (done) => {
+	it('POST /cm/upsert-container-info — Upsert new data', (done) => {
 		testData.nums = [ 1, 2, { half: 2.5 } ];
 
 		supertest
@@ -67,14 +66,14 @@ describe('Test CM endpoints', function() {
 			.expect(200, testData, done);
 	});
 
-	it('GET /cm/delete-container-info — No data', (done) => {
+	it('POST /cm/delete-container-info — No data', (done) => {
 		supertest
 			.post('/cm/delete-container-info')
 			.auth(process.env.CM_KEY)
 			.expect(400, 'Missing parameters', done);
 	});
 
-	it('GET /cm/delete-container-info — No name', (done) => {
+	it('POST /cm/delete-container-info — No name', (done) => {
 		supertest
 			.post('/cm/delete-container-info')
 			.auth(process.env.CM_KEY)
@@ -83,7 +82,7 @@ describe('Test CM endpoints', function() {
 			.expect(400, 'Missing parameters', done);
 	});
 
-	it('GET /cm/delete-container-info — With name', (done) => {
+	it('POST /cm/delete-container-info — With name', (done) => {
 		supertest
 			.post('/cm/delete-container-info')
 			.auth(process.env.CM_KEY)

--- a/test/cm.js
+++ b/test/cm.js
@@ -1,0 +1,94 @@
+process.env.CM_KEY = 'chrC9e52tR5ljd+02Shg6khojHNUpAhaqAplQ1jFgCw='
+
+var supertest = require('supertest')(require('../main.js'));
+var assert = require('assert');
+
+describe('Test CM endpoints', function() {
+	it('GET /cm/upsert-container-info — No API key', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.expect(401, 'Missing API Key', done);
+	});
+
+
+	it('GET /cm/upsert-container-info — Invalid key (in header)', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.set('X-Api-Key', 'aaa')
+			.expect(401, 'Unauthorized: Arbiter key invalid', done);
+	});
+
+	it('GET /cm/upsert-container-info — Invalid key (as basic auth)', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth('aaa')
+			.expect(401, 'Unauthorized: Arbiter key invalid', done);
+	});
+
+	it('GET /cm/upsert-container-info — No data', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.expect(400, 'Missing parameters', done);
+	});
+
+	it('GET /cm/upsert-container-info — No name', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send({})
+			.expect(400, 'Missing parameters', done);
+	});
+
+	var testData = {
+		name: 'test-store'
+	};
+
+	it('GET /cm/upsert-container-info — Minimum required', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testData)
+			.expect('Content-Type', /json/)
+			.expect(200, testData, done);
+	});
+
+	it('GET /cm/upsert-container-info — Upsert new data', (done) => {
+		testData.nums = [ 1, 2, { half: 2.5 } ];
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testData)
+			.expect('Content-Type', /json/)
+			.expect(200, testData, done);
+	});
+
+	it('GET /cm/delete-container-info — No data', (done) => {
+		supertest
+			.post('/cm/delete-container-info')
+			.auth(process.env.CM_KEY)
+			.expect(400, 'Missing parameters', done);
+	});
+
+	it('GET /cm/delete-container-info — No name', (done) => {
+		supertest
+			.post('/cm/delete-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send({})
+			.expect(400, 'Missing parameters', done);
+	});
+
+	it('GET /cm/delete-container-info — With name', (done) => {
+		supertest
+			.post('/cm/delete-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testData)
+			.expect(200, done);
+	});
+});

--- a/test/hypercat.js
+++ b/test/hypercat.js
@@ -18,7 +18,7 @@ describe('Test top-level root catalogue', function() {
 		foo: 'bar'
 	};
 
-	it('GET /cm/upsert-container-info — Register non-store', (done) => {
+	it('POST /cm/upsert-container-info — Insert non-store', (done) => {
 		supertest
 			.post('/cm/upsert-container-info')
 			.auth(process.env.CM_KEY)
@@ -36,7 +36,7 @@ describe('Test top-level root catalogue', function() {
 			.expect(200, cat, done);
 	});
 
-	it('GET /cm/upsert-container-info — Upsert non-store', (done) => {
+	it('POST /cm/upsert-container-info — Update non-store', (done) => {
 		testStore.type = 'something-that-is-not-a-store';
 
 		supertest
@@ -56,9 +56,9 @@ describe('Test top-level root catalogue', function() {
 			.expect(200, cat, done);
 	});
 
-	var expected = null;
+	var expected;
 
-	it('GET /cm/upsert-container-info — Upsert store', (done) => {
+	it('POST /cm/upsert-container-info — Update store', (done) => {
 		testStore.type = 'store';
 
 		expected = JSON.parse(JSON.stringify(testStore));
@@ -85,7 +85,7 @@ describe('Test top-level root catalogue', function() {
 			.expect(200, expected, done);
 	});
 
-	it('GET /cat — After store registered', (done) => {
+	it('POST /cat — After store registered', (done) => {
 		cat.items.push(expected.catItem);
 
 		supertest

--- a/test/hypercat.js
+++ b/test/hypercat.js
@@ -1,0 +1,118 @@
+process.env.CM_KEY = 'chrC9e52tR5ljd+02Shg6khojHNUpAhaqAplQ1jFgCw='
+
+var supertest = require('supertest')(require('../main.js'));
+var assert = require('assert');
+var cat = JSON.parse(JSON.stringify(require('../base-cat.json')));
+
+describe('Test top-level root catalogue', function() {
+	it('GET /cat — Empty', (done) => {
+		supertest
+			.get('/cat')
+			.auth(process.env.CM_KEY)
+			.expect('Content-Type', /json/)
+			.expect(200, cat, done);
+	});
+
+	var testStore = {
+		name: 'test-store',
+		foo: 'bar'
+	};
+
+	it('GET /cm/upsert-container-info — Register non-store', (done) => {
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, testStore, done);
+	});
+
+	it('GET /cat — Still empty', (done) => {
+		supertest
+			.get('/cat')
+			.auth(process.env.CM_KEY)
+			.expect('Content-Type', /json/)
+			.expect(200, cat, done);
+	});
+
+	it('GET /cm/upsert-container-info — Upsert non-store', (done) => {
+		testStore.type = 'something-that-is-not-a-store';
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, testStore, done);
+	});
+
+	it('GET /cat — Still empty', (done) => {
+		supertest
+			.get('/cat')
+			.auth(process.env.CM_KEY)
+			.expect('Content-Type', /json/)
+			.expect(200, cat, done);
+	});
+
+	var expected = null;
+
+	it('GET /cm/upsert-container-info — Upsert store', (done) => {
+		testStore.type = 'store';
+
+		expected = JSON.parse(JSON.stringify(testStore));
+		expected.catItem = {
+			'item-metadata': [
+				{
+					'rel': 'urn:X-hypercat:rels:isContentType',
+					'val': 'application/vnd.hypercat.catalogue+json'
+				},
+				{
+					'rel': 'urn:X-hypercat:rels:hasDescription:en',
+					'val': testStore.name
+				}
+			],
+			href: 'https://' + testStore.name + ':8080'
+		};
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, expected, done);
+	});
+
+	it('GET /cat — After store registered', (done) => {
+		cat.items.push(expected.catItem);
+
+		supertest
+			.get('/cat')
+			.auth(process.env.CM_KEY)
+			.expect('Content-Type', /json/)
+			.expect(200, cat, done);
+	});
+
+	it('GET /cm/delete-container-info — Deregister store', (done) => {
+		supertest
+			.post('/cm/delete-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send({ name: testStore.name })
+			.expect(200, done);
+	});
+
+	it('GET /cat — After store deregistered', (done) => {
+		cat.items = [];
+
+		supertest
+			.get('/cat')
+			.auth(process.env.CM_KEY)
+			.expect('Content-Type', /json/)
+			.expect(200, cat, done);
+	});
+
+
+});

--- a/test/stores.js
+++ b/test/stores.js
@@ -1,0 +1,114 @@
+process.env.CM_KEY = 'chrC9e52tR5ljd+02Shg6khojHNUpAhaqAplQ1jFgCw='
+
+var supertest = require('supertest')(require('../main.js'));
+var assert = require('assert');
+
+describe('Test store endpoints', function() {
+	var storeKey = '8MDlgBNXfmklmQVTrJxfIwAjo8j5nIrE8aeFVIdn6Kg=';
+
+	it('GET /store/secret — No API key', (done) => {
+		supertest
+			.get('/store/secret')
+			.send()
+			.expect(401, 'Missing API key', done);
+	});
+
+	var testStore = {};
+
+	it('POST /cm/upsert-container-info — Add store', (done) => {
+		testStore.name = 'test-store';
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, testStore, done);
+	});
+
+	it('GET /store/secret — Unknown API key (should never happen)', (done) => {
+		supertest
+			.get('/store/secret')
+			.auth(storeKey)
+			.expect(401, 'Invalid API key', done);
+	});
+
+	it('POST /cm/upsert-container-info — Update store key', (done) => {
+		testStore.key = storeKey;
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, testStore, done);
+	});
+
+	it('GET /store/secret — Container type unknown (should never happen)', (done) => {
+		supertest
+			.get('/store/secret')
+			.auth(storeKey)
+			.expect(500, 'Container type unknown by arbiter', done);
+	});
+
+	it('POST /cm/upsert-container-info — Update container type to non-store', (done) => {
+		testStore.type = 'app';
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, testStore, done);
+	});
+
+	it('GET /store/secret — Container type non-store', (done) => {
+		supertest
+			.get('/store/secret')
+			.auth(storeKey)
+			.expect(403, 'Container type "' + testStore.type + '" cannot use arbiter token minting capabilities as it is not a store type', done);
+	});
+
+	it('POST /cm/upsert-container-info — Update container type to store', (done) => {
+		testStore.type = 'store';
+
+		var expected = JSON.parse(JSON.stringify(testStore));
+		expected.catItem = {
+			'item-metadata': [
+				{
+					'rel': 'urn:X-hypercat:rels:isContentType',
+					'val': 'application/vnd.hypercat.catalogue+json'
+				},
+				{
+					'rel': 'urn:X-hypercat:rels:hasDescription:en',
+					'val': testStore.name
+				}
+			],
+			href: 'https://' + testStore.name + ':8080'
+		};
+
+		supertest
+			.post('/cm/upsert-container-info')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect('Content-Type', /json/)
+			.expect(200, expected, done);
+	});
+
+	it('GET /store/secret — No API key', (done) => {
+		supertest
+			.get('/store/secret')
+			.auth(storeKey)
+			.set('Content-Type', 'application/json')
+			.send(testStore)
+			.expect(function (res) {
+				// TODO: Error handling
+				res.text = Buffer.from(res.text, 'base64').length === 32;
+			})
+			.expect(200, true, done);
+	});
+});


### PR DESCRIPTION
Also minor unrelated change at https://github.com/me-box/databox-arbiter/pull/12/commits/1eafc67b26fe1f5082d689e164cc883a2d95d8d8.

Only missing unit test is for `/token`, which relies on SLAs being passed like [here](https://github.com/me-box/databox-container-manager/blob/CM-in-docker/src/container-manager.js#L679) but at different points (e.g. after user interaction). Alternatively, the permissions → routes (previously paths) transformation can happen in the CM, and only the routes can be passed to the arbiter.

At the moment, route-based permissions are fully working, but are simply kept wide open until the above is implemented. On doing so, #8 will likewise be resolved.