### PR TITLE
Add two new CM endpoints for modifying routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,83 @@ NB: CM arbiter key MUST be provided as per section 7.1 of the [Hypercat 3.0 spec
   - 401:
     - Missing API key (see description above)
     - Unauthorized: Arbiter key invalid
+  - 400: Missing parameters
+
+#### /cm/add-container-routes
+
+##### Description
+
+Method: POST
+
+Adds permissible routes to the record of containers maintained by the arbiter for a particular container.
+
+Routes are encoded directly into tokens (as macaroon caveats). Routes are JSON-formatted method-path pairs. The arbiter is indifferent to methods.
+
+	{
+		"GET":  "/some/path",
+		"POST": [ "/a/b", "/a/c" ],
+		"ETC":  "/*"
+	}
+
+Paths are JSON-formatted whitelists of accessible endpoints formatted as defined [here](https://github.com/pillarjs/path-to-regexp#parameters) and are testable [here](http://forbeslindesay.github.io/express-route-tester/). They can be a single path string or an array of path strings. More information [here](docs/further-info.md) (*NB: Outdated*).
+
+NB: CM arbiter key MUST be provided as per section 7.1 of the [Hypercat 3.0 specs](http://shop.bsigroup.com/upload/276778/PAS_212.pdf). The arbiter will not accept requests that don't include a key that matches that passed to it in the `CM_KEY` environment variable on launch.
+
+##### Parameters
+
+  - name: Container name
+  - routes: A routes object
+
+##### Response
+
+###### Success
+
+  - 200: [JSON-formatted container routes after modification]
+
+###### Error
+
+  - 401:
+    - Missing API key (see description above)
+    - Unauthorized: Arbiter key invalid
+  - 400: Missing parameters
+
+#### /cm/delete-container-routes
+
+##### Description
+
+Method: POST
+
+Removes all occurrences of provided routes in the record of containers maintained by the arbiter for a particular container. Note that the provided routes must match those in the arbiter records exactly (wildcards and regular expressions do not apply here; only on validation store-side).
+
+Routes are encoded directly into tokens (as macaroon caveats). Routes are JSON-formatted method-path pairs. The arbiter is indifferent to methods.
+
+	{
+		"GET":  "/some/path",
+		"POST": [ "/a/b", "/a/c" ],
+		"ETC":  "/*"
+	}
+
+Paths are JSON-formatted whitelists of accessible endpoints formatted as defined [here](https://github.com/pillarjs/path-to-regexp#parameters) and are testable [here](http://forbeslindesay.github.io/express-route-tester/). They can be a single path string or an array of path strings. More information [here](docs/further-info.md) (*NB: Outdated*).
+
+NB: CM arbiter key MUST be provided as per section 7.1 of the [Hypercat 3.0 specs](http://shop.bsigroup.com/upload/276778/PAS_212.pdf). The arbiter will not accept requests that don't include a key that matches that passed to it in the `CM_KEY` environment variable on launch.
+
+##### Parameters
+
+  - name: Container name
+  - routes: A routes object
+
+##### Response
+
+###### Success
+
+  - 200: [JSON-formatted container routes after modification]
+
+###### Error
+
+  - 401:
+    - Missing API key (see description above)
+    - Unauthorized: Arbiter key invalid
+  - 400: Missing parameters
 
 ### Store-facing
 _(for Databox developers)_

--- a/main.js
+++ b/main.js
@@ -139,7 +139,7 @@ app.post('/cm/add-container-routes', function (req, res) {
 
 	// TODO: Error if not yet in in records?
 	var container = containers[data.name] = containers[data.name] || { name: data.name };
-	container.routes = container.routes || [];
+	container.routes = container.routes || {};
 
 	for (method in data.routes) {
 		var paths = data.routes[method];
@@ -163,7 +163,7 @@ app.post('/cm/delete-container-routes', function (req, res) {
 
 	// TODO: Error if not yet in in records?
 	var container = containers[data.name] = containers[data.name] || { name: data.name };
-	container.routes = container.routes || [];
+	container.routes = container.routes || {};
 
 	for (method in data.routes) {
 		var paths = data.routes[method];

--- a/main.js
+++ b/main.js
@@ -129,6 +129,54 @@ app.post('/cm/delete-container-info', function (req, res) {
 
 /**********************************************************/
 
+app.post('/cm/add-container-routes', function (req, res) {
+	var data = req.body;
+
+	if (data == null || !data.name || !data.routes) {
+		res.status(400).send('Missing parameters');
+		return;
+	}
+
+	// TODO: Error if not yet in in records?
+	var container = containers[data.name] = containers[data.name] || { name: data.name };
+	container.routes = container.routes || [];
+
+	for (method in data.routes) {
+		var paths = data.routes[method];
+		paths = typeof paths === 'string' ? [ paths ] : paths;
+		container.routes[method] = container.routes[method] || [];
+		Array.prototype.push.apply(container.routes[method], paths);
+	}
+
+	res.json(container.routes);
+});
+
+/**********************************************************/
+
+app.post('/cm/delete-container-routes', function (req, res) {
+	var data = req.body;
+
+	if (data == null || !data.name || !data.routes) {
+		res.status(400).send('Missing parameters');
+		return;
+	}
+
+	// TODO: Error if not yet in in records?
+	var container = containers[data.name] = containers[data.name] || { name: data.name };
+	container.routes = container.routes || [];
+
+	for (method in data.routes) {
+		var paths = data.routes[method];
+		paths = typeof paths === 'string' ? [ paths ] : paths;
+		container.routes[method] = container.routes[method] || [];
+		container.routes[method] = container.routes[method].filter(path => !paths.includes(path));
+	}
+
+	res.json(container.routes);
+});
+
+/**********************************************************/
+
 // Serve root Hypercat catalogue
 app.get('/cat', function(req, res){
 	var cat = JSON.parse(JSON.stringify(baseCat));
@@ -190,6 +238,7 @@ app.post('/token', function(req, res){
 app.get('/store/secret', function (req, res) {
 	if (!req.container) {
 		// NOTE: This can also happen if the CM never uploaded store key
+		//       or if the CM added routes and never upserted info
 		//       but should never happen if the CM is up to spec.
 		res.status(401).send('Invalid API key');
 		return;

--- a/test/cm.js
+++ b/test/cm.js
@@ -66,6 +66,55 @@ describe('Test CM endpoints', function() {
 			.expect(200, testData, done);
 	});
 
+	it('POST /cm/add-container-routes — Add container routes', (done) => {
+		var routes = {
+			GET:  '/some/path',
+			POST: [ '/a/c', '/a/b', '/a/c' ],
+			ETC:  '/*'
+		};
+
+		var expected = {
+			GET:  [ '/some/path' ],
+			POST: [ '/a/c', '/a/b', '/a/c' ],
+			ETC:  [ '/*' ]
+		};
+
+		supertest
+			.post('/cm/add-container-routes')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: testData.name,
+				routes: routes
+			})
+			.expect('Content-Type', /json/)
+			.expect(200, expected, done);
+	});
+
+	it('POST /cm/delete-container-routes — Delete container routes', (done) => {
+		var routes = {
+			POST: [ '/a/c' ],
+			ETC:  '/*'
+		};
+
+		var expected = {
+			GET:  [ '/some/path' ],
+			POST: [ '/a/b' ],
+			ETC:  []
+		};
+
+		supertest
+			.post('/cm/delete-container-routes')
+			.auth(process.env.CM_KEY)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: testData.name,
+				routes: routes
+			})
+			.expect('Content-Type', /json/)
+			.expect(200, expected, done);
+	});
+
 	it('POST /cm/delete-container-info — No data', (done) => {
 		supertest
 			.post('/cm/delete-container-info')


### PR DESCRIPTION
This is much more convenient than requesting them from the arbiter, adding stuff, then overwriting the old, or otherwise maintaining mirrored records in the CM.