### PR TITLE
Resolve #21

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -1,0 +1,29 @@
+doctype html
+html(lang='en')
+	head
+		title Arbiter Perimission Records
+		style.
+			p, ul {
+				margin: 0;
+			}
+			.indent {
+				margin-left: 1em;
+			}
+	body
+		h1 Arbiter Permission Records
+		if !containers || !Object.keys(containers).length
+			p.indent No permissions have been granted yet
+		else
+			each container in containers
+				details.indent
+					summary= container.name
+					if !container.caveats
+						p.indent No permissions granted
+					else
+						each caveats, key in container.caveats
+							details.indent
+								- let route = JSON.parse(key);
+								summary= route.method + ' ' + route.target + route.path
+								ul
+									each caveat in caveats.length ? caveats : [ 'No additional caveats' ]
+										li= caveat

--- a/main.js
+++ b/main.js
@@ -34,8 +34,16 @@ app.use(bodyParser.urlencoded({
 	extended: true
 }));
 
-app.get('/status', function(req, res){
+//app.use(express.static('www'));
+app.set('views', '.');
+app.set('view engine', 'pug');
+
+app.get('/status', function(req, res) {
 	res.send('active');
+});
+
+app.get('/ui', function(req, res) {
+	res.render('index', { containers });
 });
 
 /**********************************************************/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox-arbiter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
     "registry": "registry.iotdatabox.com"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "macaroons.js": "^0.3.6",
     "modclean": "",
     "path-to-regexp": "^1.7.0",
+    "pug": "^2.0.0-beta11",
     "request": "^2.72.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This should help a lot for debug, but would ideally only be temporary. At some point, all arbiter records should be written into another store, and that store should be used for this kind of UI, giving us proper access control over that data, as well as logging — we would be able to see current permissions, as well as all grant/revoke history, while this only shows us current.