### PR TITLE
Allow stores to re-request the same secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ NB: Container arbiter key (see developer guide) MUST be provided as per section 
   - 401: Invalid API key (see description above)
   - 500: Container type unknown by arbiter
   - 403: Container type [type] cannot use arbiter token minting capabilities as it is not a store type
-  - 409: Store shared secret already retrieved
   - 500: Unable to register container (secret generation)
 
 

--- a/main.js
+++ b/main.js
@@ -322,7 +322,7 @@ app.get('/store/secret', function (req, res) {
 	}
 
 	if (req.container.secret) {
-		res.status(409).send('Store shared secret already retrieved');
+		res.send(req.container.secret.toString('base64'));
 		return;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox-arbiter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
     "registry": "registry.iotdatabox.com"

--- a/test/stores.js
+++ b/test/stores.js
@@ -112,12 +112,16 @@ describe('Test store endpoints', function() {
 			.expect(200, true, done);
 	});
 
-	it('GET /store/secret — Get secret', (done) => {
+	it('GET /store/secret — Get secret again', (done) => {
 		supertest
 			.get('/store/secret')
 			.auth(storeKey)
 			.set('Content-Type', 'application/json')
 			.send(testStore)
-			.expect(409, 'Store shared secret already retrieved', done);
+			.expect(function (res) {
+				// TODO: Error handling
+				res.text = Buffer.from(res.text, 'base64').length === 32;
+			})
+			.expect(200, true, done);
 	});
 });


### PR DESCRIPTION
This is to allow stores to restart seamlessly without being considered new entities. We should consider the security implications at some point — I'll open an issue for that, but for now, this means that stores relaunching don't invalidate all existing tokens, forcing apps to have to try to re-request tokens without knowing if it's because the store has restarted, or if their permissions have been revoked.