### PR TITLE
allow export-service to get macaroon secret

### DIFF
--- a/main.js
+++ b/main.js
@@ -316,7 +316,7 @@ app.get('/store/secret', function (req, res) {
 		return;
 	}
 
-	if (req.container.type !== 'store') {
+	if (req.container.type !== 'store' && req.container.type !== 'export-service') {
 		res.status(403).send('Container type "' + req.container.type + '" cannot use arbiter token minting capabilities as it is not a store type');
 		return;
 	}


### PR DESCRIPTION
as export-service is not labelled as `store` (https://github.com/me-box/databox-export-service/blob/master/Dockerfile#L28), this may be the easiest way to allow it to get macaroon secret